### PR TITLE
Bump v0.1.1 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "context-aware-policy-demo"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "context-aware-policy-demo"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2021"
 


### PR DESCRIPTION
Bump v0.1.1 policy version.        

Updates files bumping the policy version to v0.1.1

Related to https://github.com/kubewarden/kubewarden-controller/issues/479
