### PR TITLE
ci: switch to kubewarden 4.0.0 actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
 
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false
 
@@ -26,7 +26,7 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
     with:
       oci-target: ghcr.io/kubewarden/tests/context-aware-policy-demo
       artifacthub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
-    with:
-      artifacthub: false
 
   release:
     needs: test
@@ -29,4 +27,3 @@ jobs:
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@v4.0.0
     with:
       oci-target: ghcr.io/kubewarden/tests/context-aware-policy-demo
-      artifacthub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,14 @@
 on:
   push:
     branches:
-    - main
-    - master
+      - main
+      - master
     tags:
-    - 'v*'
+      - "v*"
 
 name: Release policy
 
 jobs:
-
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,5 +4,3 @@ jobs:
   test:
     name: run tests and linters
     uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
-    with:
-      artifacthub: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,6 @@ name: Continuous integration
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@36f0782e949d8597c061ca0d519f7e17a2813190 # v3.4.8
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@v4.0.0
     with:
       artifacthub: false

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,4 @@ test: fmt lint
 .PHONY: clean
 clean:
 	cargo clean
+	rm -f policy.wasm annotated-policy.wasm

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,3 @@ test: fmt lint
 .PHONY: clean
 clean:
 	cargo clean
-	rm -f policy.wasm annotated-policy.wasm artifacthub-pkg.yml

--- a/metadata.yml
+++ b/metadata.yml
@@ -18,6 +18,7 @@ annotations:
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/tests/context-aware-policy-demo
   # kubewarden specific:
   io.kubewarden.policy.title: context-aware-policy
+  io.kubewarden.policy.version: 0.1.1
   io.kubewarden.policy.description: A policy demonstrating context-aware policy features
   io.kubewarden.policy.url: https://github.com/kubewarden/context-aware-demo
   io.kubewarden.policy.source: https://github.com/kubewarden/context-aware-demo


### PR DESCRIPTION
By upgrading to this release, we don't have to keep track of
artifacthub-pkg.yml anymore.

Moreover, the version of the policy is now an annotation of the policy's
metadata.

Signed-off-by: Flavio Castelli <fcastelli@suse.com>
Co-authored-by: Víctor Cuadrado Juan <vcuadradojuan@suse.de>
