### PR TITLE
ci: dispatch release policy catalog workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,13 @@ jobs:
       packages: write
       # Required by cosign keyless signing
       id-token: write
-
     uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@80562ea704490b77f2b56ba3eadec57631d439cd # v4.2.0
     with:
       oci-target: ghcr.io/kubewarden/tests/context-aware-policy-demo
+
+  release-catalog:
+    needs: release
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-catalog.yml@80562ea704490b77f2b56ba3eadec57631d439cd # v4.2.0
+    secrets:
+      # Required to dispatch the release event to the policy-catalog repository
+      WORKFLOW_PAT: ${{ secrets.WORKFLOW_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ name: Release policy
 jobs:
   test:
     name: run tests and linters
-    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-test-policy-rust.yml@80562ea704490b77f2b56ba3eadec57631d439cd # v4.2.0
 
   release:
     needs: test
@@ -23,6 +23,6 @@ jobs:
       # Required by cosign keyless signing
       id-token: write
 
-    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@72179510783eda8c052d17279881c3f7d02f968e # v4.0.0
+    uses: kubewarden/github-actions/.github/workflows/reusable-release-policy-rust.yml@80562ea704490b77f2b56ba3eadec57631d439cd # v4.2.0
     with:
       oci-target: ghcr.io/kubewarden/tests/context-aware-policy-demo


### PR DESCRIPTION
## Description

This PR updates GitHub Actions to v4.2.0 and introduces a step that utilizes the reusable policy catalog workflow to update the catalog.